### PR TITLE
Make sure all CSS url paths get re-written to add an asset ID (aka cachebusting query string)

### DIFF
--- a/lib/jammit/compressor.rb
+++ b/lib/jammit/compressor.rb
@@ -30,7 +30,7 @@ module Jammit
     MAX_IMAGE_SIZE  = 32700
 
     # CSS asset-embedding regexes for URL rewriting.
-    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.[a-z]+)(\?\d*)?(?<anchor>#\w+)?['"]?\)/
+    EMBED_DETECTOR  = /url\(['"]?(?<path>[^\s)]+\.\w+)(\?\d*)?(?<anchor>#.+)?['"]?\)/
     EMBEDDABLE      = /[\A\/]embed\//
     EMBED_REPLACER  = /url\(__EMBED__(.+?)(\?\d+)?\)/
 


### PR DESCRIPTION
The `EMBED_DETECTOR` regular expression had a couple of bad assumptions that cause some urls to get skipped when appending an asset ID to url paths:

- It assumed that file extensions could only contain alpha characters (missing `woff2` files)
- It assumed that anchor IDs could only contain alpha characters (missing `#icon--close` etc icon anchors)